### PR TITLE
remove the Go 1.8 tag

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM resin/%%RESIN_MACHINE_NAME%%-golang:1.8 as builder
+FROM resin/%%RESIN_MACHINE_NAME%%-golang as builder
 WORKDIR /go/src/hello-world
 COPY main.go ./
 RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags '-extldflags "-static"'


### PR DESCRIPTION
Default instead to the `latest` Go version. At the moment this is a no-op, but Go 1.9 has been released. May as well future-proof this example.